### PR TITLE
feat: 공용 모달 임시 작업

### DIFF
--- a/src/shared/modal/Modal.module.scss
+++ b/src/shared/modal/Modal.module.scss
@@ -1,0 +1,60 @@
+.overlay {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  background-color: rgba(0, 0, 0, 0.8);
+  z-index: 1000;
+}
+
+.container {
+  background-color: variables.$deep-black;
+  border-radius: 12px;
+  padding: 12px 12px;
+  min-width: 295px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+
+.content {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+}
+
+@keyframes fadeIn {
+  from {
+    transform: translateY(-20px);
+    opacity: 0;
+  }
+  to {
+    transform: translateY(0);
+    opacity: 1;
+  }
+}
+
+@keyframes fadeOut {
+  from {
+    transform: translateY(0);
+    opacity: 1;
+  }
+  to {
+    transform: translateY(-20px);
+    opacity: 0;
+  }
+}
+
+.visible {
+  display: block;
+  animation: fadeIn 0.3s;
+}
+
+.hidden {
+  animation: fadeOut 0.3s;
+}

--- a/src/shared/modal/Modal.tsx
+++ b/src/shared/modal/Modal.tsx
@@ -1,0 +1,87 @@
+import { useEffect, useRef, ReactNode } from 'react';
+import styles from './index.module.scss';
+import ModalHeader from './ModalHeader';
+
+export interface ModalProps {
+  headerText?: string;
+  children?: ReactNode;
+  customModalContainerStyle?: string;
+  customModalContentStyle?: string;
+  onClose?: () => void;
+  buttonClick?: () => void;
+  isVisible?: boolean;
+  customHeader?: ReactNode;
+}
+
+const Modal = ({
+  headerText = '',
+  children = null,
+  customModalContainerStyle = '',
+  customModalContentStyle = '',
+  onClose = () => {},
+  buttonClick = () => {},
+  isVisible = false,
+  customHeader = null,
+}: ModalProps) => {
+  const modalRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        onClose();
+      }
+    };
+
+    if (isVisible) {
+      document.body.style.overflow = 'hidden';
+    } else {
+      document.body.style.overflow = '';
+    }
+
+    window.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+      document.body.style.overflow = '';
+    };
+  }, [isVisible, onClose]);
+
+  const handleOutsideClick = (e: MouseEvent) => {
+    if (modalRef.current && !modalRef.current.contains(e.target as Node)) {
+      onClose();
+    }
+  };
+
+  const handleKeyPress = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (e.key === 'Enter') {
+      buttonClick();
+    }
+  };
+
+  return (
+    <div
+      className={styles.overlay}
+      onClick={
+        handleOutsideClick as unknown as React.MouseEventHandler<HTMLDivElement>
+      }
+      onKeyUp={handleKeyPress}
+      role="button"
+      tabIndex={0}
+    >
+      <div
+        ref={modalRef}
+        className={`${styles.container} ${isVisible ? styles.visible : styles.hidden} ${customModalContainerStyle}`}
+      >
+        {customHeader ||
+          (headerText && (
+            <ModalHeader headerText={headerText} onClose={onClose} />
+          ))}
+        <div className={`${styles.content} ${customModalContentStyle}`}>
+          {children}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default Modal;

--- a/src/shared/modal/ModalHeader.module.scss
+++ b/src/shared/modal/ModalHeader.module.scss
@@ -1,0 +1,18 @@
+.container {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+
+  p {
+    color: variables.$white;
+    line-height: normal;
+    font: {
+      size: 18px;
+      weight: 500;
+    }
+  }
+
+  img {
+    display: block;
+  }
+}

--- a/src/shared/modal/ModalHeader.tsx
+++ b/src/shared/modal/ModalHeader.tsx
@@ -1,0 +1,21 @@
+import Image from 'next/image';
+import CloseIcon from '../../../public/icon/ic-close.svg';
+import styles from './ModalHeader.module.scss';
+
+interface ModalHeaderProps {
+  headerText?: string;
+  onClose?: () => void;
+}
+
+const ModalHeader: React.FC<ModalHeaderProps> = ({ headerText, onClose }) => {
+  return (
+    <div className={styles.container}>
+      <p>{headerText}</p>
+      <button type="button" onClick={onClose}>
+        <Image src={CloseIcon} alt="close" />
+      </button>
+    </div>
+  );
+};
+
+export default ModalHeader;

--- a/src/shared/modal/useModalStore.ts
+++ b/src/shared/modal/useModalStore.ts
@@ -1,0 +1,26 @@
+import { create } from 'zustand';
+
+interface ModalContent {
+  isVisible: boolean;
+  content: React.ReactNode;
+}
+
+interface ModalState {
+  modals: { [key: string]: ModalContent };
+  openModal: (id: string, content: React.ReactNode) => void;
+  closeModal: (id: string) => void;
+}
+
+const useModalStore = create<ModalState>((set) => ({
+  modals: {},
+  openModal: (id: string, content: React.ReactNode) =>
+    set((state) => ({
+      modals: { ...state.modals, [id]: { isVisible: true, content } },
+    })),
+  closeModal: (id: string) =>
+    set((state) => ({
+      modals: { ...state.modals, [id]: { isVisible: false, content: null } },
+    })),
+}));
+
+export default useModalStore;


### PR DESCRIPTION
## 📝 Description

- 
![image](https://github.com/user-attachments/assets/9b082073-d2f4-4ca2-ad35-982d074a2295)

파라미터.

![image](https://github.com/user-attachments/assets/0e0ac1e2-910d-4dda-a69b-c0fbfd4fa213)

모달 관리 스토어.


사용법

A라는 버튼을 누르면 모달 띄우고 싶은 경우, A라는 버튼있는 컴포넌트 파일에서 작업함

해당 컴포넌트 파일에서

```typescript
const { modals, openModal, closeModal } = useModalStore();
```
모달 스토어를 불러오고,

```typescript
const modalId = useRef('confirm');
```
모달에 관련된 ref를 설정한다. useReF('[여기]')  [여기]에 들어갈 값은 임의로 정해도 괜찮으나, 다른 모달이랑 중복되지 않은 단어로 설정할 필요가 있다.

```typescript
{modals[modalId.current]?.isVisible && (
        <Modal
          customModalContentStyle={styles.backButtonModal}
          onClose={handleCloseModal}
          customModalButtonStyle={styles.defaultButton}
          isVisible={modals[modalId.current]?.isVisible}
        >
          <div className={styles.modalContainer}>
            <img
              src={exclamationImage}
              className={styles.exclamationImage}
              alt="느낌표 이미지"
            />
            <p>
              페이지를 떠나시면 작성 중인 내용을 잃게 됩니다. 떠나시겠습니까?
            </p>
            <div className={styles.modalButtonContainer}>
              <Button className={styles.backButton} onClick={handleCloseModal}>
                취소
              </Button>
              <Button className={styles.confirmButton} onClick={handleGoBack}>
                확인
              </Button>
            </div>
          </div>
        </Modal>
      )}

```
이런 식으로 return문 안에서 현재 모달의 isVisible에 따라 열리고 닫히게끔 설정하고 

```typescript
<Modal>
  {children}
</Modal>
```

{children}은 본인이 작성하고 싶은 모달 안의 내용을 직접 작성해야한다.


```typescript
  const handleCloseModal = () => {
    closeModal(modalId.current);
  };
```

close부분의 handleCloseModal의 함수 내용은 위와 같이 모달을 닫을 수 있게끔 설정하는 함수도 따로 작성해주어야한다.



## 📸 Screenshot

```typescript
import Modal from '../../shared/ui/modal';
import useModalStore from '../../shared/ui/modal/useModalStore';

const 머시깽깽이 = () => {

  const modalId = useRef('confirm');
  const { modals, openModal, closeModal } = useModalStore();

  const handleOpenBackModal = () => {
    openModal(modalId.current);
  };

  const handleCloseModal = () => {
    closeModal(modalId.current);
  };
  
  return (
  <div>
  <button onClick={handleOpenBackModal}>
{modals[modalId.current]?.isVisible && (
        <Modal
          customModalContentStyle={styles.backButtonModal}
          onClose={handleCloseModal}
          customModalButtonStyle={styles.defaultButton}
          isVisible={modals[modalId.current]?.isVisible}
        >
          <div className={styles.modalContainer}>
            <img
              src={exclamationImage}
              className={styles.exclamationImage}
              alt="느낌표 이미지"
            />
            <p>
              페이지를 떠나시면 작성 중인 내용을 잃게 됩니다. 떠나시겠습니까?
            </p>
            <div className={styles.modalButtonContainer}>
              <Button className={styles.backButton} onClick={handleCloseModal}>
                취소
              </Button>
              <Button className={styles.confirmButton} onClick={handleGoBack}>
                확인
              </Button>
            </div>
          </div>
        </Modal>
      )}
</div>
  )
}


## 📢 Notes

급하게 반영한 만큼 수정할 부분이 산더미라 v2, v3에 반영하도록 하겠읍니다