### PR TITLE
fix: github desktop에서 커밋안되던 오류 수정

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
+#!/usr/bin/env bash
+. "$(dirname -- "$0")/_/husky.bash"
 
 npx lint-staged


### PR DESCRIPTION
pre-commit 세팅 파일 수정

## 📌 Related Issue

close #56 

## 📝 Description

- pre-commit 세팅 파일의 현재 내용이 github desktop 상에서 커밋 안되는 오류가 있었는데, 해당 프로그램에서도 커밋이 가능하게끔 해당 세팅 파일 내용 변경함.

