### PR TITLE
feat: 공용 드롭다운 1차 개발

### DIFF
--- a/src/shared/dropdown/Dropdown.module.scss
+++ b/src/shared/dropdown/Dropdown.module.scss
@@ -1,0 +1,33 @@
+.dropdown {
+  display: flex;
+  width: 360px;
+  padding: 10px;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 5px;
+  border-radius: 8px;
+  border: 1px solid var(--black-black_353542, #353542);
+  background: var(--black-black_252530, #252530);
+  color: var(--gray-gray_6E6E82, #6E6E82);
+  font-size: 14px;
+  font-style: normal;
+  font-weight: 400;
+  line-height: 20px;
+}
+
+.item {
+  border-radius: 6px;
+  background: var(--black-black_2E2E3A, #2E2E3A);
+  display: flex;
+  padding: 6px 20px;
+  align-items: center;
+
+  &:hover {
+    background: var(--black-black_353542, #353542);
+    color: var(--white-white_F1F1F5, #F1F1F5);
+    font-size: 14px;
+    font-style: normal;
+    font-weight: 400;
+    line-height: 20px;
+  }
+}

--- a/src/shared/dropdown/Dropdown.tsx
+++ b/src/shared/dropdown/Dropdown.tsx
@@ -1,0 +1,31 @@
+import styles from './Dropdown.module.css';
+import useDropdownStore from './useDropdown';
+
+interface DropdownProps {
+  options: string[];
+  dropdownId: string;
+}
+
+const Drowndown = ({ options, dropdownId }: DropdownProps) => {
+  const { dropdowns } = useDropdownStore();
+
+  const onClick = (value: string) => {
+    dropdowns[dropdownId].selectedOption = value;
+  };
+
+  return (
+    <div className={styles.dropdown}>
+      {options.map((option, index) => (
+        <div
+          className={styles.item}
+          key={index}
+          onClick={() => onClick(option)}
+        >
+          {option}
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default Drowndown;

--- a/src/shared/dropdown/useDropdown.ts
+++ b/src/shared/dropdown/useDropdown.ts
@@ -1,0 +1,30 @@
+import { create } from 'zustand';
+
+interface DropdownContent {
+  isVisible: boolean;
+  content: React.ReactNode;
+  selectedOption?: string;
+}
+
+interface DropdownState {
+  dropdowns: { [key: string]: DropdownContent };
+  openDropdown: (id: string, content?: React.ReactNode) => void;
+  closeDropdown: (id: string) => void;
+}
+
+const useDropdownStore = create<DropdownState>((set) => ({
+  dropdowns: {},
+  openDropdown: (id: string, content: React.ReactNode) =>
+    set((state) => ({
+      dropdowns: { ...state.dropdowns, [id]: { isVisible: true, content } },
+    })),
+  closeDropdown: (id: string) =>
+    set((state) => ({
+      dropdowns: {
+        ...state.dropdowns,
+        [id]: { isVisible: false, content: null },
+      },
+    })),
+}));
+
+export default useDropdownStore;


### PR DESCRIPTION
## 📌 Related Issue

> close #71 

## 📝 Description

- 공용 드롭다운 1차 개발. 커스텀 기능은 아직 넣지 않음. 2차 개발에서 여백 등을 수정할 수 있는 커스텀을 넣고 열고, 3차 개발에서 item에도 커스텀을 넣어 호버 애니메이션 등을 넣을 수 있게끔 고려. 그 이후 개발에서는 열리고 닫힐 때 애니메이션을 넣을지 생각중

사용법.

기본적으로 현재 모달 사용법이랑 거의 동일. useDropdown을 통해 드롭다운을 여러 개 관리할 수 있게끔 설계를 하였고, 한 창에 여러 드롭다운을 넣어도 정상적으로 작동하게끔 만듦.

input 같은 컴포넌트를 만든 후, 해당 input 컴포넌트에 클릭이벤트를 넣어, 그 클릭이벤트에서 해당 드롭다운의 isVisible 값을 조정하는 방식임

대신, 드롭다운 밖 영역을 클릭하였을때 해당 드롭다운도 같이 닫히도록 하는 편의성 구현은 해당 드롭다운을 사용하는 페이지에서 따로 작업해줘야함.

```typescript
const Drowndown = ({ options, dropdownId }: DropdownProps) => {
  const { dropdowns } = useDropdownStore();

  const onClick = (value: string) => {
    dropdowns[dropdownId].selectedOption = value;
  };
```

이런 식으로 드롭다운에서 dropdownId를 받는데,  해당 드롭다운에 대한 Id값을 받아, 그 Id값에 선택한 드롭다운 값을 저장시키도록 하고 있음

드롭다운 안의 아이템을 선택했을때 드롭다운이 닫히지 않을 수 있는데, 해당 기능을 어떻게 구현해야할지 생각하면서 추후 구현해보겠음.

