### PR TITLE
fix: 커스텀 스타일링 밀림 이슈 해결

### DIFF
--- a/src/shared/button/Button.tsx
+++ b/src/shared/button/Button.tsx
@@ -6,13 +6,9 @@ interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
 }
 
 const Button = forwardRef<HTMLButtonElement, ButtonProps>(
-  ({ children, className = '', ...props }, ref) => {
+  ({ children, className, ...props }, ref) => {
     return (
-      <button
-        ref={ref}
-        className={`${styles.maButton} ${className}`}
-        {...props}
-      >
+      <button ref={ref} className={className || styles.maButton} {...props}>
         {children}
       </button>
     );


### PR DESCRIPTION
## 📌 Related Issue

> 이슈 없작고

## 📝 Description

- 페이지 이동 시 커스텀 스타일링이 기본 스타일링에 밀려서 조건을 수정했습니다.
커스텀 스타일도 기본 스타일의 믹스인을 가져다 쓰는 거라 문제 없을 것 같긴 한데? 코드 확인해보시고, 문제 있으면 알려주세요
