### PR TITLE
feat: onChange 결합

### DIFF
--- a/src/shared/TextArea/TextArea.tsx
+++ b/src/shared/TextArea/TextArea.tsx
@@ -1,31 +1,50 @@
 'use client';
 
+import React, { forwardRef } from 'react';
 import TextCount from '../TextCount';
 import useTextCounter from '@/hook/useTextCounter';
+import ErrorMessage from '../input/component/ErrorMessage';
 import styles from './TextArea.module.scss';
 
-const TextArea = ({
-  className,
-  maxLength,
-  ...props
-}: React.TextareaHTMLAttributes<HTMLTextAreaElement>) => {
-  const { text, handleTextCounter } = useTextCounter(maxLength);
-  return (
-    <div className={styles.textareaWrapper}>
-      <textarea
-        maxLength={maxLength}
-        onChange={handleTextCounter}
-        {...props}
-        className={`${styles.textarea} ${className}`}
-      />
-      <TextCount
-        text={text}
-        maxLength={maxLength}
-        className={styles.textCount}
-      />
-    </div>
-  );
-};
+type TextAreaProps = {
+  formErrorMessage?: string | null;
+} & React.TextareaHTMLAttributes<HTMLTextAreaElement>;
+
+const TextArea = forwardRef<HTMLTextAreaElement | null, TextAreaProps>(
+  ({ maxLength, className, formErrorMessage, ...props }, ref) => {
+    const { text, handleTextCounter } = useTextCounter(maxLength);
+
+    const { onChange, ...rest } = props;
+
+    const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+      if (onChange) {
+        onChange(e);
+      }
+
+      handleTextCounter(e);
+    };
+
+    return (
+      <div className={styles.textareaWrapper}>
+        <textarea
+          ref={ref}
+          maxLength={maxLength}
+          onChange={handleChange}
+          {...rest}
+          className={`${styles.textarea} ${className}`}
+        />
+
+        <ErrorMessage formError={formErrorMessage} />
+
+        <TextCount
+          text={text}
+          maxLength={maxLength}
+          className={styles.textCount}
+        />
+      </div>
+    );
+  }
+);
 
 TextArea.displayName = 'TextArea';
 export default TextArea;

--- a/src/shared/input/Input.tsx
+++ b/src/shared/input/Input.tsx
@@ -51,6 +51,20 @@ const Input = forwardRef<HTMLInputElement | null, InputProps>(
       [styles.errorStatus]: formErrorMessage,
     });
 
+    const { onChange, ...rest } = props;
+
+    const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+      if (onChange) {
+        onChange(e);
+      }
+
+      if (type === 'file') {
+        handleFileChange(e);
+      } else {
+        handleTextCounter(e);
+      }
+    };
+
     return (
       <div
         className={
@@ -67,12 +81,10 @@ const Input = forwardRef<HTMLInputElement | null, InputProps>(
             id={id}
             ref={mergeRefs([ref, toggleRef])}
             maxLength={maxLength}
-            onChange={(e) =>
-              type === 'file' ? handleFileChange(e) : handleTextCounter(e)
-            }
+            onChange={handleChange}
             multiple={multiple}
             className={inputClassName}
-            {...props}
+            {...rest}
           />
           <PwToggleBtn
             type={type}
@@ -90,6 +102,7 @@ const Input = forwardRef<HTMLInputElement | null, InputProps>(
           formError={formErrorMessage}
           fileError={fileErrorMessage}
         />
+
         <FilePreview
           type={type}
           filePreviews={filePreviews}


### PR DESCRIPTION
## 📌 Related Issue

> #104 

## 📝 Description

- 리액트 훅 폼의 onChange 때문에 input onChange가 동작 안 하길래 결합했습니다.
input 하위 컴포넌트들 일부 동작 확인했는데, 안 되는 거 있으면 말씀주세요.
- textarea도 훅 폼 에러 받을 수 있게 임시 수정했습니다. 
디자인이 영 별로인 것 같아서 추후 에러 처리 수정해보겠습니다.
