### PR TITLE
fix: 드롭다운 선택값 고정 이슈 해결

### DIFF
--- a/src/shared/dropdown/Dropdown.module.scss
+++ b/src/shared/dropdown/Dropdown.module.scss
@@ -16,6 +16,8 @@
   $font-weight: 400,
   $line-height: 20px,
   $margin-top: 5px,
+  $z-index: 100,
+  $position: absolute,
 ) {
   display: $display;
   width: $width;
@@ -32,6 +34,8 @@
   font-weight: $font-weight;
   line-height: $line-height;
   margin-top: $margin-top;
+  z-index: $z-index;
+  position: $position;
 }
 
 .dropdown {

--- a/src/shared/dropdown/Dropdown.tsx
+++ b/src/shared/dropdown/Dropdown.tsx
@@ -1,6 +1,7 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, CSSProperties } from 'react';
 import styles from './Dropdown.module.scss';
 import useDropdownStore from './useDropdownStore';
+import { createPortal } from 'react-dom';
 
 interface DropdownProps {
   options: string[];
@@ -84,25 +85,38 @@ const Dropdown = ({
     //화살표로도 드롭다운 컨트롤 할 수 있게 수정
   };
 
+  const parentRect = parentRef.current?.getBoundingClientRect();
+
+  const dropdownStyle: CSSProperties = {
+    top: `${parentRect?.bottom}px`,
+    left: `${parentRect?.left}px`,
+  };
+
   return (
-    <div
-      ref={dropdownRef}
-      className={`${customDropdownStyle || styles.dropdown} ${customVisible || styles.visible}`}
-      onKeyUp={handleKeyPress}
-      role="button"
-      tabIndex={0}
-    >
-      {options.map((option, index) => (
+    <>
+      {createPortal(
         <div
-          className={`${customItemStyle || styles.item}`}
-          key={index}
-          onClick={() => handleItemClick(option)}
-          tabIndex={index++}
+          ref={dropdownRef}
+          className={`${customDropdownStyle || styles.dropdown} ${customVisible || styles.visible}`}
+          style={dropdownStyle}
+          onKeyUp={handleKeyPress}
+          role="button"
+          tabIndex={0}
         >
-          {option}
-        </div>
-      ))}
-    </div>
+          {options.map((option, index) => (
+            <div
+              className={`${customItemStyle || styles.item}`}
+              key={index}
+              onClick={() => handleItemClick(option)}
+              tabIndex={index++}
+            >
+              {option}
+            </div>
+          ))}
+        </div>,
+        document.body
+      )}
+    </>
   );
 };
 

--- a/src/shared/dropdown/useDropdownStore.ts
+++ b/src/shared/dropdown/useDropdownStore.ts
@@ -22,7 +22,11 @@ const useDropdownStore = create<DropdownState>((set) => ({
     set((state) => ({
       dropdowns: {
         ...state.dropdowns,
-        [id]: { isVisible: false, content: null },
+        [id]: {
+          ...state.dropdowns[id],
+          isVisible: false,
+          content: null,
+        },
       },
     })),
 }));

--- a/src/shared/dropdown/useDropdownStore.ts
+++ b/src/shared/dropdown/useDropdownStore.ts
@@ -16,17 +16,27 @@ const useDropdownStore = create<DropdownState>((set) => ({
   dropdowns: {},
   openDropdown: (id: string, content: React.ReactNode) =>
     set((state) => ({
-      dropdowns: { ...state.dropdowns, [id]: { isVisible: true, content } },
+      dropdowns: {
+        ...state.dropdowns,
+        [id]: {
+          isVisible: true,
+          content,
+          selectedOption: state.dropdowns[id]?.selectedOption,
+        },
+      },
     })),
   closeDropdown: (id: string) =>
     set((state) => ({
       dropdowns: {
         ...state.dropdowns,
-        [id]: {
-          ...state.dropdowns[id],
-          isVisible: false,
-          content: null,
-        },
+        [id]: { ...state.dropdowns[id], isVisible: false, content: null },
+      },
+    })),
+  setSelectedOption: (id: string, option: string) =>
+    set((state) => ({
+      dropdowns: {
+        ...state.dropdowns,
+        [id]: { ...state.dropdowns[id], selectedOption: option },
       },
     })),
 }));


### PR DESCRIPTION
## 📌 Related Issue

> close #109 

## 📝 Description

- 드롭다운에서 아이템을 선택하면 해당 값이 고정이 되지 않아 재차 불러 올 수 없었는데, 해당 문제 해결
- 드롭다운의 position이 기본값이라 다른 컴포넌트를 밀어내면서 렌더링하여 기존 디자인을 망쳤는데, absolute를 주며 정상적으로 렌더링 가능하게끔 수정
- createPortal 반영 (사용법이 맞는지는 모르겠으나..)
- zustand에서 selectedOption만 수정할 수 있는 함수 추가

## 📸 Screenshot

- 문제의 드롭다운

![filtering-problem](https://github.com/user-attachments/assets/9cbf3c7d-6192-4493-9abe-52f9b2a18b96)



- 해결된 드롭다운


![filtering-solution](https://github.com/user-attachments/assets/f9f8689d-5959-4c44-8c34-00add937c4c0)

